### PR TITLE
feat(qml): add RiverONE checkpoint-to-QASM adapter

### DIFF
--- a/examples/riverone_qml.py
+++ b/examples/riverone_qml.py
@@ -1,0 +1,199 @@
+"""导入 RiverONE ``TQVQC`` checkpoint 并生成可执行的 QASM2。
+
+直接运行本文件时使用下方“用户配置区”。命令行参数仍可临时覆盖这些配置。
+默认在本地模拟器执行；选择真机设备时才访问服务器。
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import getpass
+import os
+from pathlib import Path
+
+import numpy as np
+
+import tyxonq as tq
+from tyxonq.applications.qml import (
+    load_riverone_vqc,
+    riverone_to_qasm2,
+)
+
+
+# ============================== 用户配置区 ==============================
+CHECKPOINT: Path | None = None  # 可直接填写 checkpoint 路径。
+VQC_INDEX = 0
+AMPLITUDES: Path | None = None  # 可填一维 .npy；None 表示使用演示振幅。
+SHOTS = 1024
+DEVICE = "simulator"  # 可选 "simulator"、"homebrew_s2"、"homebrew_s3"。
+TYXONQ_API_KEY = ""
+# =======================================================================
+
+
+_BASES = ("X", "Y", "Z")
+_DEVICES = ("simulator", "homebrew_s2", "homebrew_s3")
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="导入 RiverONE TQVQC，并生成可模拟或提交的三份 QASM2。"
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=CHECKPOINT,
+        help="RiverONE checkpoint；也可在程序开头的 CHECKPOINT 中设置。",
+    )
+    parser.add_argument(
+        "--vqc-index",
+        type=int,
+        default=VQC_INDEX,
+        help="选择第几条 VQC；默认使用程序开头的 VQC_INDEX。",
+    )
+    parser.add_argument(
+        "--amplitudes",
+        type=Path,
+        default=AMPLITUDES,
+        help="一维 .npy 振幅；默认使用程序开头的 AMPLITUDES。",
+    )
+    parser.add_argument(
+        "--shots",
+        type=int,
+        default=SHOTS,
+        help="每个测量基的 shots；默认使用程序开头的 SHOTS。",
+    )
+    parser.add_argument(
+        "--device",
+        choices=_DEVICES,
+        default=DEVICE,
+        help="执行设备；默认使用本地 simulator。",
+    )
+    args = parser.parse_args(argv)
+    if args.checkpoint is None:
+        parser.error("请在用户配置区设置 CHECKPOINT，或使用 --checkpoint 指定。")
+    if args.device not in _DEVICES:
+        parser.error(f"设备必须是 {_DEVICES} 之一。")
+    if args.vqc_index < 0:
+        parser.error("--vqc-index 不能为负数。")
+    if args.shots < 1:
+        parser.error("--shots 必须大于 0。")
+    if args.amplitudes is not None and args.amplitudes.suffix.lower() != ".npy":
+        parser.error("--amplitudes 必须是 .npy 文件。")
+    return args
+
+
+def _task_id(task: object) -> str:
+    handle = getattr(task, "handle", None)
+    value = getattr(handle, "id", None) or getattr(task, "id", None)
+    return str(value) if value is not None else "unknown"
+
+
+def _load_amplitudes(path: Path | None, n_qubits: int) -> np.ndarray:
+    if path is None:
+        print("未提供 --amplitudes，使用 [1, 2, ..., 2^n] 确定性演示输入。")
+        return np.arange(1, (1 << n_qubits) + 1, dtype=np.float64)
+    return np.load(path, allow_pickle=False)
+
+
+def _print_result(basis: str, values: Sequence[float]) -> None:
+    items = ", ".join(f"{basis}{wire}={value:.8f}" for wire, value in enumerate(values))
+    print(f"{basis}: {items}")
+
+
+def _expectations_from_counts(
+    counts: Mapping[str, int], n_qubits: int
+) -> tuple[float, ...]:
+    """按 TyxonQ 的 q0-first 位序从采样 counts 计算单比特期望值。"""
+
+    samples: list[tuple[str, int]] = []
+    for raw_bits, raw_count in counts.items():
+        bits = str(raw_bits).replace(" ", "")
+        if len(bits) != n_qubits or any(bit not in "01" for bit in bits):
+            raise ValueError(f"模拟器返回了非法测量态：{raw_bits!r}")
+        samples.append((bits, int(raw_count)))
+
+    shots = sum(count for _, count in samples)
+    if shots <= 0:
+        raise ValueError("模拟器没有返回有效 shots。")
+
+    return tuple(
+        sum((1 if bits[wire] == "0" else -1) * count for bits, count in samples)
+        / shots
+        for wire in range(n_qubits)
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    spec = load_riverone_vqc(args.checkpoint, vqc_index=args.vqc_index)
+    amplitudes = _load_amplitudes(args.amplitudes, spec.n_qubits)
+
+    qasm_by_basis = riverone_to_qasm2(spec, amplitudes)
+    print(
+        f"已生成 RiverONE VQC {args.vqc_index} 的三份 QASM2："
+        f"{spec.n_qubits} qubits。"
+    )
+
+    if args.device == "simulator":
+        # 模拟器当前逐条接收 QASM，避免触发批量 QASM 的解析限制。
+        results_by_basis: dict[str, tuple[float, ...]] = {}
+        for basis in _BASES:
+            tasks = tq.api.submit_task(
+                provider="simulator",
+                device="statevector",
+                source=qasm_by_basis[basis],
+                shots=args.shots,
+            )
+            task_list = tasks if isinstance(tasks, list) else [tasks]
+            if len(task_list) != 1:
+                raise RuntimeError(
+                    f"{basis} 基本地模拟预期返回 1 个任务，实际为 {len(task_list)} 个。"
+                )
+
+            task = task_list[0]
+            details = tq.api.get_task_details(task)
+            if details.get("error"):
+                raise RuntimeError(f"{basis} 基本地模拟失败：{details['error']}")
+            counts = details.get("result") or {}
+            results_by_basis[basis] = _expectations_from_counts(
+                counts, spec.n_qubits
+            )
+
+        print(
+            "X/Y/Z 本地模拟完成："
+            f"device=statevector，每个测量基 shots={args.shots}"
+        )
+        for basis in _BASES:
+            _print_result(basis, results_by_basis[basis])
+        return 0
+
+    token = (
+        TYXONQ_API_KEY
+        or os.getenv("TYXONQ_API_KEY")
+        or getpass.getpass("请输入 TYXONQ_API_KEY：")
+    )
+    if not token:
+        raise SystemExit("未提供 TYXONQ_API_KEY，任务未提交。")
+
+    tq.set_token(token, provider="tyxonq", device=args.device)
+    tasks = tq.api.submit_task(
+        provider="tyxonq",
+        device=args.device,
+        source=[qasm_by_basis[basis] for basis in _BASES],
+        shots=args.shots,
+    )
+    task_list = tasks if isinstance(tasks, list) else [tasks]
+    if len(task_list) != 1:
+        raise RuntimeError(
+            f"预期返回 1 个批量任务，实际为 {len(task_list)} 个。"
+        )
+    print(
+        f"X/Y/Z 批量任务已提交：task_id={_task_id(task_list[0])}，"
+        f"device={args.device}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tyxonq/applications/__init__.py
+++ b/src/tyxonq/applications/__init__.py
@@ -6,10 +6,10 @@ stabilizes test collection across environments.
 """
 
 
-from . import chem
+from . import chem, qml
 
 __all__ = [
     "chem",
+    "qml",
 ]
-
 

--- a/src/tyxonq/applications/qml/__init__.py
+++ b/src/tyxonq/applications/qml/__init__.py
@@ -1,0 +1,13 @@
+"""量子机器学习应用接口。"""
+
+from .riverone import (
+    RiverONEVQCSpec,
+    load_riverone_vqc,
+    riverone_to_qasm2,
+)
+
+__all__ = [
+    "RiverONEVQCSpec",
+    "load_riverone_vqc",
+    "riverone_to_qasm2",
+]

--- a/src/tyxonq/applications/qml/riverone.py
+++ b/src/tyxonq/applications/qml/riverone.py
@@ -1,0 +1,315 @@
+"""RiverONE ``TQVQC`` checkpoint 到 OpenQASM 2 的适配器。
+
+本模块导入训练后的变分门参数，并生成包含振幅编码、数据重新上传
+语义和 X/Y/Z 测量的线路。经典 ``WeightEncoder``、``BlockHyper`` 和
+完整 ``VQCWeightGenerator`` 不属于本适配范围。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import math
+from pathlib import Path
+import re
+from typing import Any
+
+import numpy as np
+
+
+_ROTATION_NAMES = ("rx", "ry", "rz")
+_MEASUREMENT_BASES = ("X", "Y", "Z")
+_QASM_BASIS_GATES = ("cx", "h", "rz", "rx", "cz")
+_REUPLOAD_EVERY = 2
+_STATE_KEY_PATTERN = re.compile(
+    r"^vqcs\.(?P<vqc>\d+)\.variational\.l(?P<layer>\d+)_w(?P<wire>\d+)\."
+    r"(?P<gate>rx|ry|rz)\.params$"
+)
+
+AngleTriple = tuple[float, float, float]
+AngleLayer = tuple[AngleTriple, ...]
+
+
+@dataclass(frozen=True)
+class RiverONEVQCSpec:
+    """一条训练后的 RiverONE ``TQVQC``。"""
+
+    n_qubits: int
+    n_layers: int
+    angles: Sequence[Sequence[Sequence[float]]]
+    reupload_every: int = _REUPLOAD_EVERY
+
+    def __post_init__(self) -> None:
+        if self.n_qubits < 2:
+            raise ValueError("RiverONE VQC 至少需要 2 个量子比特。")
+        if self.n_layers < 1:
+            raise ValueError("RiverONE VQC 至少需要 1 层。")
+        if self.reupload_every < 1:
+            raise ValueError("reupload_every 必须大于 0。")
+        if len(self.angles) != self.n_layers:
+            raise ValueError(
+                f"angles 层数应为 {self.n_layers}，实际为 {len(self.angles)}。"
+            )
+
+        # 把外部列表规范化为不可变元组，同时逐项检查角度形状和数值。
+        normalized_layers: list[AngleLayer] = []
+        for layer_index, layer in enumerate(self.angles):
+            if len(layer) != self.n_qubits:
+                raise ValueError(
+                    f"第 {layer_index} 层应包含 {self.n_qubits} 个量子比特，"
+                    f"实际为 {len(layer)}。"
+                )
+            normalized_wires: list[AngleTriple] = []
+            for wire_index, gate_angles in enumerate(layer):
+                if len(gate_angles) != 3:
+                    raise ValueError(
+                        f"第 {layer_index} 层第 {wire_index} 个量子比特必须按"
+                        " [RX, RY, RZ] 提供 3 个角度。"
+                    )
+                values = tuple(float(value) for value in gate_angles)
+                if not all(math.isfinite(value) for value in values):
+                    raise ValueError(
+                        f"第 {layer_index} 层第 {wire_index} 个量子比特包含非有限角度。"
+                    )
+                normalized_wires.append(values)  # type: ignore[arg-type]
+            normalized_layers.append(tuple(normalized_wires))
+
+        object.__setattr__(self, "angles", tuple(normalized_layers))
+
+
+def _checkpoint_state(checkpoint_path: Path) -> Mapping[str, Any]:
+    if not checkpoint_path.is_file():
+        raise FileNotFoundError(f"未找到 RiverONE checkpoint：{checkpoint_path}")
+
+    import torch
+
+    payload = torch.load(
+        str(checkpoint_path),
+        map_location="cpu",
+        weights_only=True,
+    )
+    if not isinstance(payload, Mapping):
+        raise ValueError("RiverONE checkpoint 顶层必须是字典。")
+    state = payload.get("state")
+    if not isinstance(state, Mapping):
+        raise ValueError("RiverONE checkpoint 必须包含字典字段 'state'。")
+    return state
+
+
+def _infer_shape(state: Mapping[str, Any], vqc_index: int) -> tuple[int, int]:
+    available_indices: set[int] = set()
+    layers: set[int] = set()
+    wires: set[int] = set()
+
+    for key in state:
+        match = _STATE_KEY_PATTERN.match(str(key))
+        if match is None:
+            continue
+        current_vqc = int(match.group("vqc"))
+        available_indices.add(current_vqc)
+        if current_vqc == vqc_index:
+            layers.add(int(match.group("layer")))
+            wires.add(int(match.group("wire")))
+
+    if vqc_index not in available_indices:
+        available = ", ".join(str(index) for index in sorted(available_indices)) or "无"
+        raise IndexError(
+            f"checkpoint 中不存在 vqc_index={vqc_index}；可用索引：{available}。"
+        )
+
+    n_layers = max(layers) + 1
+    n_qubits = max(wires) + 1
+    for layer in range(n_layers):
+        for wire in range(n_qubits):
+            for gate in _ROTATION_NAMES:
+                key = (
+                    f"vqcs.{vqc_index}.variational.l{layer}_w{wire}.{gate}.params"
+                )
+                if key not in state:
+                    raise ValueError(
+                        f"checkpoint 缺少 VQC {vqc_index} 的 l{layer}_w{wire}.{gate} 参数。"
+                    )
+    return n_qubits, n_layers
+
+
+def _scalar_parameter(value: Any, *, location: str) -> float:
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    if hasattr(value, "numel") and int(value.numel()) != 1:
+        raise ValueError(f"{location} 必须恰好包含一个角度。")
+    if hasattr(value, "reshape"):
+        value = value.reshape(-1)[0]
+    if hasattr(value, "item"):
+        value = value.item()
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{location} 包含非有限角度。")
+    return result
+
+
+def load_riverone_vqc(
+    checkpoint_path: str | Path,
+    vqc_index: int = 0,
+) -> RiverONEVQCSpec:
+    """从 RiverONE checkpoint 加载一条训练后的 ``TQVQC``。"""
+
+    if vqc_index < 0:
+        raise ValueError("vqc_index 不能为负数。")
+
+    checkpoint = Path(checkpoint_path).expanduser().resolve()
+    state = _checkpoint_state(checkpoint)
+    n_qubits, n_layers = _infer_shape(state, vqc_index)
+
+    # checkpoint 已保存完整门参数，直接读取即可，不需要导入 TorchQuantum。
+    layers: list[list[AngleTriple]] = []
+    for layer in range(n_layers):
+        wire_angles: list[AngleTriple] = []
+        for wire in range(n_qubits):
+            values = tuple(
+                _scalar_parameter(
+                    state[
+                        f"vqcs.{vqc_index}.variational."
+                        f"l{layer}_w{wire}.{gate_name}.params"
+                    ],
+                    location=f"l{layer}_w{wire}.{gate_name}.params",
+                )
+                for gate_name in _ROTATION_NAMES
+            )
+            wire_angles.append(values)  # type: ignore[arg-type]
+        layers.append(wire_angles)
+
+    return RiverONEVQCSpec(
+        n_qubits=n_qubits,
+        n_layers=n_layers,
+        angles=layers,
+        reupload_every=_REUPLOAD_EVERY,
+    )
+
+
+def _normalize_amplitudes(
+    amplitudes: Sequence[complex] | np.ndarray,
+    n_qubits: int,
+) -> np.ndarray:
+    """复现 TorchQuantum ``AmplitudeEncoder`` 的补零和归一化。"""
+
+    raw_values = np.asarray(amplitudes)
+    dtype = np.complex128 if np.iscomplexobj(raw_values) else np.float64
+    values = np.asarray(raw_values, dtype=dtype)
+    if values.ndim != 1:
+        raise ValueError("amplitudes 必须是一维数组。")
+    if values.size == 0:
+        raise ValueError("amplitudes 不能为空。")
+
+    dimension = 1 << n_qubits
+    if values.size > dimension:
+        raise ValueError(
+            f"amplitudes 最多包含 {dimension} 个元素，实际为 {values.size}。"
+        )
+    if not np.all(np.isfinite(values.real)) or not np.all(np.isfinite(values.imag)):
+        raise ValueError("amplitudes 包含非有限值。")
+
+    norm = float(np.linalg.norm(values))
+    if not math.isfinite(norm) or norm == 0.0:
+        raise ValueError("amplitudes 不能是全零向量。")
+
+    state = np.zeros(dimension, dtype=np.complex128)
+    state[: values.size] = values / norm
+    return state
+
+
+def _active_layers(spec: RiverONEVQCSpec) -> Sequence[AngleLayer]:
+    # RiverONE 的 re-upload 会直接覆盖状态，之前的门不再影响最终输出。
+    start = ((spec.n_layers - 1) // spec.reupload_every) * spec.reupload_every
+    return spec.angles[start:]
+
+
+def _append_variational_layers(
+    circuit: Any,
+    spec: RiverONEVQCSpec,
+) -> None:
+    for layer in _active_layers(spec):
+        for wire, (theta_rx, theta_ry, theta_rz) in enumerate(layer):
+            circuit.rx(theta_rx, wire)
+            circuit.ry(theta_ry, wire)
+            circuit.rz(theta_rz, wire)
+        for wire in range(spec.n_qubits - 1):
+            circuit.cx(wire, wire + 1)
+        circuit.cx(spec.n_qubits - 1, 0)
+
+
+def _qiskit_amplitudes(state: np.ndarray, n_qubits: int) -> np.ndarray:
+    """把 RiverONE 的 q0-first 状态轴转换为 Qiskit 的小端序。"""
+
+    axes = tuple(reversed(range(n_qubits)))
+    ordered = state.reshape((2,) * n_qubits).transpose(axes).reshape(-1)
+    # RiverONE 的 WeightEncoder 产生实数。保留实数 dtype 可避免 Qiskit
+    # 在大型纯实状态上误走数值更不稳定的复数 isometry 分解。
+    if np.all(ordered.imag == 0.0):
+        return ordered.real
+    return ordered
+
+
+def _build_qiskit_circuit(spec: RiverONEVQCSpec, state: np.ndarray, basis: str) -> Any:
+    from qiskit import QuantumCircuit
+    from qiskit.circuit.library import StatePreparation
+
+    circuit = QuantumCircuit(spec.n_qubits, spec.n_qubits)
+    circuit.append(
+        StatePreparation(_qiskit_amplitudes(state, spec.n_qubits)),
+        range(spec.n_qubits),
+    )
+    _append_variational_layers(circuit, spec)
+
+    # 真机最终仍执行 Z 读出；X/Y 通过标准换基门获得对应期望值。
+    if basis == "X":
+        for wire in range(spec.n_qubits):
+            circuit.h(wire)
+    elif basis == "Y":
+        for wire in range(spec.n_qubits):
+            circuit.sdg(wire)
+            circuit.h(wire)
+    circuit.measure(range(spec.n_qubits), range(spec.n_qubits))
+    return circuit
+
+
+def riverone_to_qasm2(
+    spec: RiverONEVQCSpec,
+    amplitudes: Sequence[complex] | np.ndarray,
+) -> dict[str, str]:
+    """生成 RiverONE X/Y/Z 三种测量基对应的 OpenQASM 2。"""
+
+    from qiskit import qasm2, transpile
+
+    state = _normalize_amplitudes(amplitudes, spec.n_qubits)
+    qasm_by_basis: dict[str, str] = {}
+    allowed_operations = set(_QASM_BASIS_GATES) | {"measure", "barrier"}
+
+    for basis in _MEASUREMENT_BASES:
+        # Qiskit 2.4 对部分 bit-reversal 状态无法直接完成高层综合；先展开
+        # StatePreparation 可稳定进入后续基础门分解。
+        circuit = _build_qiskit_circuit(spec, state, basis).decompose()
+        compiled = transpile(
+            circuit,
+            basis_gates=list(_QASM_BASIS_GATES),
+            optimization_level=1,
+        )
+        unexpected = set(compiled.count_ops()) - allowed_operations
+        if unexpected:
+            names = ", ".join(sorted(unexpected))
+            raise RuntimeError(f"QASM2 编译后仍包含服务器基础门之外的操作：{names}")
+
+        source = qasm2.dumps(compiled)
+        if not all(token in source for token in ("OPENQASM 2", "qreg", "creg", "measure")):
+            raise RuntimeError(f"{basis} 基未生成完整的 OpenQASM 2。")
+        qasm_by_basis[basis] = source
+
+    return qasm_by_basis
+
+
+__all__ = [
+    "RiverONEVQCSpec",
+    "load_riverone_vqc",
+    "riverone_to_qasm2",
+]

--- a/src/tyxonq/devices/hardware/tyxonq/driver.py
+++ b/src/tyxonq/devices/hardware/tyxonq/driver.py
@@ -89,21 +89,21 @@ def submit_task(
     lang: str = "OPENQASM",
     **kws: Any,
 ) -> List[TyxonQTask]:
-    # Type and content validation for homebrew_s2
+    # Homebrew 门线路统一接收 OpenQASM 2 字符串。
     dev = device.split("::")[-1]
     
-    if dev == "homebrew_s2":
+    if dev in ("homebrew_s2", "homebrew_s3"):
         # Normalize source to list for uniform validation
         sources_to_validate = source if isinstance(source, (list, tuple)) else [source]
         
         for src in sources_to_validate:
             if not isinstance(src, str):
                 raise TypeError(
-                    f"homebrew_s2 requires QASM2 source code (str), got {type(src).__name__}"
+                    f"{dev} requires QASM2 source code (str), got {type(src).__name__}"
                 )
-            if not ("qreg" in src or "creg" in src):
+            if "qreg" not in src or "creg" not in src:
                 raise ValueError(
-                    f"homebrew_s2 source must be valid QASM2 format (must contain qreg/creg)"
+                    f"{dev} source must be valid QASM2 format (must contain qreg/creg)"
                 )
     
     # Minimal pass-through; compilation handled elsewhere
@@ -219,5 +219,3 @@ def remove_task(task: TyxonQTask, token: Optional[str] = None) -> Dict[str, Any]
     r = requests.post(url, json={"id": task.id}, headers=_headers(token), timeout=15)
     r.raise_for_status()
     return r.json()
-
-

--- a/tests_core_module/test_riverone_qml_adapter.py
+++ b/tests_core_module/test_riverone_qml_adapter.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+from tyxonq.applications.qml import (
+    RiverONEVQCSpec,
+    load_riverone_vqc,
+    riverone_to_qasm2,
+)
+
+
+def _checkpoint_state(
+    *, n_qubits: int = 2, n_layers: int = 1, vqc_index: int = 1
+) -> dict[str, object]:
+    state: dict[str, object] = {}
+    value = 0.1
+    for layer in range(n_layers):
+        for wire in range(n_qubits):
+            for gate in ("rx", "ry", "rz"):
+                state[
+                    f"vqcs.{vqc_index}.variational."
+                    f"l{layer}_w{wire}.{gate}.params"
+                ] = value
+                value += 0.1
+    return state
+
+
+def _write_checkpoint(path: Path, state: dict[str, object]) -> Path:
+    torch.save({"state": state}, path)
+    return path
+
+
+def _zero_spec(n_qubits: int = 2, n_layers: int = 1) -> RiverONEVQCSpec:
+    return RiverONEVQCSpec(
+        n_qubits=n_qubits,
+        n_layers=n_layers,
+        angles=[[[0.0, 0.0, 0.0] for _ in range(n_qubits)] for _ in range(n_layers)],
+    )
+
+
+def test_spec_rejects_non_finite_angles():
+    with pytest.raises(ValueError, match="非有限角度"):
+        RiverONEVQCSpec(
+            n_qubits=2,
+            n_layers=1,
+            angles=[[[0.1, 0.2, float("nan")], [0.4, 0.5, 0.6]]],
+        )
+
+
+def test_load_riverone_vqc_directly_without_torchquantum(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    checkpoint = _write_checkpoint(tmp_path / "checkpoint.pt", _checkpoint_state())
+    monkeypatch.setitem(sys.modules, "torchquantum", None)
+
+    spec = load_riverone_vqc(checkpoint, vqc_index=1)
+
+    assert spec.n_qubits == 2
+    assert spec.n_layers == 1
+    assert spec.reupload_every == 2
+    actual = [value for layer in spec.angles for wire in layer for value in wire]
+    assert actual == pytest.approx([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+
+
+def test_load_riverone_vqc_requires_state_mapping(tmp_path: Path):
+    checkpoint = tmp_path / "checkpoint.pt"
+    torch.save({}, checkpoint)
+
+    with pytest.raises(ValueError, match="必须包含字典字段 'state'"):
+        load_riverone_vqc(checkpoint)
+
+
+def test_load_riverone_vqc_rejects_unknown_index(tmp_path: Path):
+    checkpoint = _write_checkpoint(
+        tmp_path / "checkpoint.pt", _checkpoint_state(vqc_index=0)
+    )
+
+    with pytest.raises(IndexError, match="不存在 vqc_index=1"):
+        load_riverone_vqc(checkpoint, vqc_index=1)
+
+
+def test_load_riverone_vqc_rejects_missing_gate(tmp_path: Path):
+    state = _checkpoint_state(vqc_index=0)
+    del state["vqcs.0.variational.l0_w1.rz.params"]
+    checkpoint = _write_checkpoint(tmp_path / "checkpoint.pt", state)
+
+    with pytest.raises(ValueError, match="缺少 VQC 0 的 l0_w1.rz 参数"):
+        load_riverone_vqc(checkpoint)
+
+
+def test_load_riverone_vqc_rejects_non_scalar_parameter(tmp_path: Path):
+    state = _checkpoint_state(vqc_index=0)
+    state["vqcs.0.variational.l0_w0.rx.params"] = torch.tensor([0.1, 0.2])
+    checkpoint = _write_checkpoint(tmp_path / "checkpoint.pt", state)
+
+    with pytest.raises(ValueError, match="必须恰好包含一个角度"):
+        load_riverone_vqc(checkpoint)
+
+
+@pytest.mark.parametrize(
+    ("amplitudes", "message"),
+    [
+        (np.array([], dtype=float), "不能为空"),
+        (np.zeros(4), "全零"),
+        (np.ones((2, 2)), "一维"),
+        (np.ones(5), "最多包含 4"),
+        (np.array([1.0, np.nan]), "非有限"),
+    ],
+)
+def test_qasm2_rejects_invalid_amplitudes(amplitudes, message):
+    with pytest.raises(ValueError, match=message):
+        riverone_to_qasm2(_zero_spec(), amplitudes)
+
+
+def test_reupload_discards_layers_before_last_state_overwrite():
+    final_layer = [[0.2, -0.1, 0.3], [0.4, 0.5, -0.2]]
+    zero_layer = [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+    changed_layer = [[1.2, -0.7, 0.8], [-0.4, 1.1, 0.9]]
+    reference = RiverONEVQCSpec(
+        n_qubits=2,
+        n_layers=3,
+        angles=[zero_layer, zero_layer, final_layer],
+    )
+    changed = RiverONEVQCSpec(
+        n_qubits=2,
+        n_layers=3,
+        angles=[changed_layer, changed_layer, final_layer],
+    )
+    amplitudes = np.array([1.0, 2.0, 3.0, 4.0])
+
+    assert riverone_to_qasm2(changed, amplitudes) == riverone_to_qasm2(
+        reference, amplitudes
+    )
+
+
+def test_qasm2_xyz_has_expected_measurement_semantics():
+    qiskit = pytest.importorskip("qiskit")
+    from qiskit.quantum_info import Pauli, Statevector
+
+    qasm_by_basis = riverone_to_qasm2(_zero_spec(), [2.0])
+    expected = {"X": (0.0, 0.0), "Y": (0.0, 0.0), "Z": (1.0, 1.0)}
+
+    assert tuple(qasm_by_basis) == ("X", "Y", "Z")
+    for basis, source in qasm_by_basis.items():
+        parsed = qiskit.qasm2.loads(source)
+        assert parsed.num_qubits == 2
+        assert parsed.num_clbits == 2
+        assert parsed.count_ops().get("measure") == 2
+        assert set(parsed.count_ops()) <= {
+            "rx",
+            "rz",
+            "h",
+            "cx",
+            "cz",
+            "measure",
+            "barrier",
+        }
+
+        state = Statevector.from_instruction(
+            parsed.remove_final_measurements(inplace=False)
+        )
+        actual = []
+        for wire in range(2):
+            pauli = ["I", "I"]
+            pauli[1 - wire] = "Z"
+            actual.append(float(np.real(state.expectation_value(Pauli("".join(pauli))))))
+        assert actual == pytest.approx(expected[basis], abs=1e-7)
+
+
+def test_real_eight_qubit_qasm2_is_parseable():
+    qiskit = pytest.importorskip("qiskit")
+    qasm_by_basis = riverone_to_qasm2(
+        _zero_spec(n_qubits=8, n_layers=6),
+        np.arange(1, 257, dtype=float),
+    )
+
+    for source in qasm_by_basis.values():
+        circuit = qiskit.qasm2.loads(source)
+        assert circuit.num_qubits == 8
+        assert circuit.num_clbits == 8
+        assert circuit.count_ops().get("measure") == 8
+        assert "state_preparation" not in circuit.count_ops()
+        assert "initialize" not in circuit.count_ops()

--- a/tests_core_module/test_tyxonq_driver.py
+++ b/tests_core_module/test_tyxonq_driver.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from tyxonq.devices.hardware.tyxonq import driver
+
+
+class _FakeResponse:
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, object]:
+        return {"id": "mock-task", "status": "submitted", "success": True}
+
+
+def test_homebrew_s3_sends_qasm2_payload(monkeypatch: pytest.MonkeyPatch):
+    """离线验证 homebrew_s3 客户端发送合同。"""
+
+    received: dict[str, object] = {}
+
+    def fake_post(url, *, json, headers, timeout):
+        received.update(
+            url=url,
+            payload=json,
+            headers=headers,
+            timeout=timeout,
+        )
+        return _FakeResponse()
+
+    monkeypatch.setattr(driver.requests, "post", fake_post)
+    qasms = [
+        f"OPENQASM 2.0; qreg q[1]; creg c[1]; // {basis}"
+        for basis in ("X", "Y", "Z")
+    ]
+
+    tasks = driver.submit_task(
+        "homebrew_s3",
+        token="test-token",
+        source=qasms,
+        shots=1024,
+    )
+
+    assert received["url"].endswith("/api/v1/tasks/submit_task")
+    assert received["headers"] == {"Authorization": "Bearer test-token"}
+    assert received["timeout"] == 30
+    assert received["payload"] == [
+        {
+            "device": "homebrew_s3",
+            "shots": 1024,
+            "source": qasm,
+            "version": "1",
+            "lang": "OPENQASM",
+        }
+        for qasm in qasms
+    ]
+    assert [task.id for task in tasks] == ["mock-task"]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "OPENQASM 2.0; qreg q[1];",
+        "OPENQASM 2.0; creg c[1];",
+    ],
+)
+def test_homebrew_s3_rejects_qasm_without_registers(source: str):
+    with pytest.raises(ValueError, match="homebrew_s3 source must be valid QASM2"):
+        driver.submit_task(
+            "homebrew_s3",
+            token="test-token",
+            source=source,
+        )

--- a/tests_examples/test_riverone_qml_example.py
+++ b/tests_examples/test_riverone_qml_example.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tyxonq.applications.qml import RiverONEVQCSpec
+
+
+def _load_example_module():
+    example_path = Path(__file__).parents[1] / "examples" / "riverone_qml.py"
+    spec = importlib.util.spec_from_file_location("riverone_qml_example", example_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    # 用户可能把 example 配成真机设备；测试必须强制使用本地模拟器。
+    module.DEVICE = "simulator"
+    module.TYXONQ_API_KEY = ""
+    return module
+
+
+def _model_spec() -> RiverONEVQCSpec:
+    return RiverONEVQCSpec(
+        n_qubits=2,
+        n_layers=1,
+        angles=[[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]],
+    )
+
+
+def _qasm() -> dict[str, str]:
+    return {
+        basis: f"OPENQASM 2.0; qreg q[2]; creg c[2]; // {basis}"
+        for basis in ("X", "Y", "Z")
+    }
+
+
+def test_example_requires_checkpoint_when_not_configured(capsys):
+    module = _load_example_module()
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main([])
+
+    assert exc_info.value.code == 2
+    assert "请在用户配置区设置 CHECKPOINT" in capsys.readouterr().err
+
+
+def test_example_loads_npy_amplitudes(monkeypatch, tmp_path: Path):
+    module = _load_example_module()
+    amplitudes_path = tmp_path / "input.npy"
+    expected = np.array([1.0, 2.0, 3.0, 4.0])
+    np.save(amplitudes_path, expected)
+    received = []
+    monkeypatch.setattr(module, "load_riverone_vqc", lambda *args, **kwargs: _model_spec())
+    monkeypatch.setattr(
+        module,
+        "riverone_to_qasm2",
+        lambda spec, amplitudes: received.append(amplitudes.copy()) or _qasm(),
+    )
+    monkeypatch.setattr(
+        module.tq.api,
+        "submit_task",
+        lambda **kwargs: [SimpleNamespace(id="sim-task")],
+    )
+    monkeypatch.setattr(
+        module.tq.api,
+        "get_task_details",
+        lambda task: {"result": {"00": 1}, "error": ""},
+    )
+
+    assert (
+        module.main(
+            [
+                "--checkpoint",
+                "/external/model.pt",
+                "--amplitudes",
+                str(amplitudes_path),
+            ]
+        )
+        == 0
+    )
+    assert np.array_equal(received[0], expected)
+
+
+def test_example_runs_xyz_qasm_on_local_simulator(monkeypatch, capsys):
+    module = _load_example_module()
+    qasm = _qasm()
+    monkeypatch.setattr(module, "load_riverone_vqc", lambda *args, **kwargs: _model_spec())
+    monkeypatch.setattr(module, "riverone_to_qasm2", lambda *args, **kwargs: qasm)
+    monkeypatch.setattr(
+        module.tq,
+        "set_token",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("本地模拟器不应配置真机 token")
+        ),
+    )
+
+    submitted = []
+
+    def fake_submit_task(**kwargs):
+        submitted.append(kwargs)
+        return [SimpleNamespace(id=f"sim-{len(submitted)}")]
+
+    monkeypatch.setattr(module.tq.api, "submit_task", fake_submit_task)
+    monkeypatch.setattr(
+        module.tq.api,
+        "get_task_details",
+        lambda task: {"result": {"00": 192, "10": 64}, "error": ""},
+    )
+
+    result = module.main(
+        [
+            "--checkpoint",
+            "/external/checkpoint.pt",
+            "--shots",
+            "256",
+        ]
+    )
+
+    assert result == 0
+    assert submitted == [
+        {
+            "provider": "simulator",
+            "device": "statevector",
+            "source": qasm[basis],
+            "shots": 256,
+        }
+        for basis in ("X", "Y", "Z")
+    ]
+    stdout = capsys.readouterr().out
+    assert stdout.count("本地模拟完成") == 1
+    assert "task_id=" not in stdout
+    assert stdout.index("X/Y/Z 本地模拟完成") < stdout.index("X: X0=")
+    assert "X: X0=0.50000000, X1=1.00000000" in stdout
+
+
+def test_example_submits_xyz_in_one_api_call(monkeypatch, capsys):
+    module = _load_example_module()
+    qasm = _qasm()
+    monkeypatch.setattr(module, "load_riverone_vqc", lambda *args, **kwargs: _model_spec())
+    monkeypatch.setattr(module, "riverone_to_qasm2", lambda *args, **kwargs: qasm)
+    monkeypatch.setenv("TYXONQ_API_KEY", "test-token")
+
+    configured = []
+    submitted = []
+    monkeypatch.setattr(
+        module.tq,
+        "set_token",
+        lambda token, provider, device: configured.append((token, provider, device)),
+    )
+
+    def fake_submit_task(**kwargs):
+        submitted.append(kwargs)
+        return [SimpleNamespace(id="batch-task")]
+
+    monkeypatch.setattr(module.tq.api, "submit_task", fake_submit_task)
+
+    result = module.main(
+        [
+            "--checkpoint",
+            "/external/checkpoint.pt",
+            "--shots",
+            "256",
+            "--device",
+            "homebrew_s3",
+        ]
+    )
+
+    assert result == 0
+    assert configured == [("test-token", "tyxonq", "homebrew_s3")]
+    assert submitted == [
+        {
+            "provider": "tyxonq",
+            "device": "homebrew_s3",
+            "source": [qasm["X"], qasm["Y"], qasm["Z"]],
+            "shots": 256,
+        }
+    ]
+    assert "batch-task" in capsys.readouterr().out


### PR DESCRIPTION
Add RiverONE checkpoint loading, X/Y/Z QASM2 generation, local simulation, and Homebrew S2/S3 submission support.